### PR TITLE
Made KnotTheoryDirectory[] work with Mathematica 12

### DIFF
--- a/KnotTheory/init.m
+++ b/KnotTheory/init.m
@@ -51,9 +51,7 @@ KnotTheoryVersionString[] = StringJoin[
   ToString[KnotTheoryVersion[6]]
 ]
 
-KnotTheoryDirectory[] = (
-  File /. Flatten[FileInformation[ToFileName[#,"KnotTheory"]] & /@ ($Path /. "." -> Directory[])]
-)
+KnotTheoryDirectory[] = DirectoryName[$InputFileName]
 
 (* might be dangerous if KnotTheoryDirectory[] is somehow incorrect! *)
 If[!MemberQ[$Path, ParentDirectory[KnotTheoryDirectory[]]],


### PR DESCRIPTION
This fixes #1.  Credit for the fix is due to Marco Marengon and Thomas Hockenhull.